### PR TITLE
Added config to enable/disable the mixer rectangle halo

### DIFF
--- a/config.py
+++ b/config.py
@@ -52,3 +52,8 @@ QUANTIZE_BEHAVIOR = 0
 # - If set to 0, quantization will be applied to both start and end time of notes
 # - If set to 1 (default), quantization will be applied only to start time of notes
 QUANTIZE_MODE = 1
+
+# Mixer halo behavior 
+# - If set to 0, nothing will appear over the current group of tracks
+# - If set to 1 (default), a rectangle halo will appear over the current group of tracks
+MIXER_HALO_BEHAVIOR = 1

--- a/mixer_definition.py
+++ b/mixer_definition.py
@@ -225,7 +225,8 @@ class Mixer:
                 self.trackLimit = 8
 
             # Updates FL Studio mixer rectangle halo
-            ui.miDisplayRect(self.trackFirst, self.trackFirst + self.trackLimit - 1, midi.MaxInt)
+            if config.MIXER_HALO_BEHAVIOR == 1:
+                ui.miDisplayRect(self.trackFirst, self.trackFirst + self.trackLimit - 1, midi.MaxInt)
 
         # Updates mute and solo status of the currently selected track (for MUTE and SOLO button lights)
         if mixer.isTrackMuted(mixer.trackNumber()) != self.isCurrentTrackMuted:


### PR DESCRIPTION
Just wanted to add this config in case people like me wanted to turn off the rectangle that shows up on the mixer.